### PR TITLE
Correctifs responsive mobile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -24,7 +24,7 @@ html {
 }
 
 body {
-    max-width: 1360px; /*1440 - (2 x 40 padding) */
+    width: max(100%, 1360px); /*1440 - (2 x 40 padding) */
     display: flex;
     justify-content: center;
     margin: 0;
@@ -569,6 +569,7 @@ input[type="checkbox"] {
 
     .main-container {
         padding: 0;
+        width: 100%;
     }
     
     .card-title {
@@ -748,10 +749,3 @@ input[type="checkbox"] {
         margin-bottom: 40px;
     }
 }
-
-/* résolution bug d'affichage marges blanches entre 695px et 767px
-@media (max-width: 695px) {
-    #filtre_cat {
-        padding-right: 382px;
-    }
-}*/

--- a/css/style.css
+++ b/css/style.css
@@ -327,6 +327,7 @@ input[type="checkbox"] {
     border-radius: 20px;
     filter: drop-shadow(0px 3px 15px rgba(0, 0, 0, 0.1));
     margin-bottom: 30px;
+    border: 4px solid white;
 }
 
 .hebergement-cards img {
@@ -375,6 +376,7 @@ input[type="checkbox"] {
     height: 150px;
     display: flex;
     margin-bottom: 30px;
+    border: 4px solid white;
 }
 
 .populaires-cards img {
@@ -636,7 +638,7 @@ input[type="checkbox"] {
 
     #filtre_cat {
         padding-left: 10px;
-        padding-right: 82px;
+        width: 350px;
     }
 
     #filtre_cat p {
@@ -688,7 +690,7 @@ input[type="checkbox"] {
     }
 
     .populaires-cards a {
-        width: min(100%, 315px);
+        width: 100%;
     }
 
     .hebergement {
@@ -710,7 +712,7 @@ input[type="checkbox"] {
     }
 
     .hebergement-conteneur a {
-        width: min(100%, 310px);
+        width: 100%;
     }
 
     .activite {
@@ -727,7 +729,7 @@ input[type="checkbox"] {
     }
 
     .activite-conteneur a {
-        width: min(100%, 315px);
+        width: 100%;
         height: 200px;
         margin-bottom: 15px;
     }
@@ -747,9 +749,9 @@ input[type="checkbox"] {
     }
 }
 
-/* résolution bug d'affichage marges blanches entre 695px et 767px */
+/* résolution bug d'affichage marges blanches entre 695px et 767px
 @media (max-width: 695px) {
     #filtre_cat {
-        padding-right: 10px;
+        padding-right: 382px;
     }
-}
+}*/

--- a/index.html
+++ b/index.html
@@ -28,12 +28,12 @@
                 <div id="en-tete_img">
                     <img src="./images/logo/Booki.png" alt="logo">
                 </div>
-                <div>
+                <nav>
                     <ul>
                         <li><a href="#hebergement">Hébergements</a></li>
                         <li><a href="#activite">Activités</a></li>
                     </ul>
-                </div>
+                </nav>
             </div>
         </header>
         <main>


### PR DESCRIPTION
**Principal :** 
Étirement de l'affichage des cards du bord droit au bord gauche de l'écran dans la présentaion mobile.
Affichage des filtres thématiques par bloc de 4 sur toutes les dimensions d'écrans possibles entre 365px et 767px.
**Secondaire :** 
Remplacement de la balise <div> par une balise <nav> pour contenir les liens de navigation dans le header.
correction sur une marge blanche que apparaissait entre le body et le bord de l'écran entre 695 px et 767px.
Ajout de bordures blanches sur les cards hébergement qui avaient accidentellement disparues.
